### PR TITLE
Enable ZH for deepl service

### DIFF
--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -24,7 +24,7 @@ export class DeepL implements TranslationService {
   }
 
   supportsLanguage(language: string) {
-    return ['en', 'de', 'fr', 'es', 'pt', 'it', 'nl', 'pl', 'ru'].includes(
+    return ['en', 'de', 'fr', 'es', 'pt', 'it', 'nl', 'pl', 'ru', 'zh'].includes(
       language,
     );
   }


### PR DESCRIPTION
Deepl added support for chinese (zh) already earlier this year: https://www.deepl.com/en/blog/20200319.html