### PR TITLE
Ensure non-zero-exit in case of unexpected exceptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -420,4 +420,5 @@ translate(
   console.log(chalk.bgRed(e.message));
   console.log(chalk.bgRed(e.stack));
   console.log();
+  process.exit(1);
 });


### PR DESCRIPTION
Hi,

I use `json-autotranslate` via continuous integration, therefore it is important that any failure will exit with a non-zero return code.
This is a fix for the case of unexpected exceptions.