### PR TITLE
feat(output): Added tabWidth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Options:
   -h, --help                                    output usage information
   --directory-structure <default|ngx-translate> the locale directory structure (default: "default")
   --decode-escapes                              decodes escaped HTML entities like &#39; into normal UTF-8 characters
+  --tab-width <value> (default: 2)              the number of whitespace characters used in JSON indentation 
 ```
 
 ## Contributing

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
   evaluateFilePath,
   FileType,
   DirectoryStructure,
-  TranslatableFile
+  TranslatableFile,
 } from './util/file-system';
 import { matcherMap } from './matchers';
 
@@ -94,7 +94,7 @@ const translate = async (
   service: keyof typeof serviceMap = 'google-translate',
   matcher: keyof typeof matcherMap = 'icu',
   decodeEscapes = false,
-  tabWidth?: number, // no default value, as we try to auto-detect it
+  cmdLineTabWidth?: string, // no default value, as we try to auto-detect it
   config?: string,
 ) => {
   const workingDir = path.resolve(process.cwd(), inputDir);
@@ -135,7 +135,8 @@ const translate = async (
     );
   }
 
-  if (tabWidth === undefined) {
+  let tabWidth: number;
+  if (cmdLineTabWidth === undefined) {
     // Try detecting tabWidth from .prettierrc config file in working directory.
     const prettierConfigPath = path.resolve('.prettierrc');
     if (fs.existsSync(prettierConfigPath)) {
@@ -160,9 +161,11 @@ const translate = async (
           ),
         );
       }
+    } else {
+      tabWidth = 2;
     }
-  } else {
-    tabWidth = 2;
+  }else {
+    tabWidth = Number.parseInt(cmdLineTabWidth);
   }
 
   console.log(

--- a/src/util/file-system.ts
+++ b/src/util/file-system.ts
@@ -63,6 +63,7 @@ export const loadTranslations = (
 export const fixSourceInconsistencies = (
   directory: string,
   cacheDir: string,
+  tabWidth: number
 ) => {
   const files = loadTranslations(directory).filter(f => f.type === 'natural');
 
@@ -74,12 +75,12 @@ export const fixSourceInconsistencies = (
 
     fs.writeFileSync(
       path.resolve(directory, file.name),
-      JSON.stringify(fixedContent, null, 2) + '\n',
+      JSON.stringify(fixedContent, null, tabWidth) + '\n',
     );
 
     fs.writeFileSync(
       path.resolve(cacheDir, file.name),
-      JSON.stringify(fixedContent, null, 2) + '\n',
+      JSON.stringify(fixedContent, null, tabWidth) + '\n',
     );
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,6 +1784,11 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
+"fsevents@^2.1.2":
+  "integrity" "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ=="
+  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz"
+  "version" "2.1.3"
+
 "gaxios@^3.0.0":
   "integrity" "sha512-+6WPeVzPvOshftpxJwRi2Ozez80tn/hdtOUag7+gajDHRJvAblKxTFSSMPtr2hmnLy7p0mvYz0rMXLBl8pSO7Q=="
   "resolved" "https://registry.npmjs.org/gaxios/-/gaxios-3.2.0.tgz"


### PR DESCRIPTION
So far, all JSON output was always indented with 2 spaces. This caused issues with Git diffs if the expected indentation is different. I've added a command line option `--tab-width <value>` with which you can specify indentation. There's also a .prettierrc autodetection for tabWidth.