### PR TITLE
DeepL: Fix formality for unsupported languages

### DIFF
--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -107,7 +107,10 @@ export class DeepL implements TranslationService {
     url.searchParams.append('target_lang', to.toUpperCase());
     url.searchParams.append('auth_key', this.apiKey);
     url.searchParams.append('auth_key', this.apiKey);
-    url.searchParams.append('formality', this.formality);
+    if (this.supportsFormality(to)) {
+      //only append formality to avoid bad request error from deepl for languages with unsupported formality
+      url.searchParams.append('formality', this.formality);
+    }
 
     const response = await fetch(String(url));
 

--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -34,7 +34,7 @@ export class DeepL implements TranslationService {
     this.interpolationMatcher = interpolationMatcher;
     const languages = await this.fetchLanguages();
     this.supportedLanguages = this.formatLanguages(languages);
-    this.formalityLanguages = new Set(['de', 'fr', 'it', 'es', 'pt', 'nl', 'pl', 'pt', 'ru']);
+    this.formalityLanguages = this.getFormalityLanguages(languages);
     this.decodeEscapes = decodeEscapes;
   }
 


### PR DESCRIPTION
Right now if the formality is set for an unsupported language, DeepL will throw a 400.

This prevents the usage of the formality when a language is required that does not support it.

In this PR the formality is only append to the DeepL API URL when the language supports it.