### PR TITLE
added support for plurals/nested tokens for icu format

### DIFF
--- a/src/matchers/icu.spec.ts
+++ b/src/matchers/icu.spec.ts
@@ -1,5 +1,5 @@
 import { matchIcu } from './icu';
-import { replaceInterpolations } from '.';
+import { reInsertInterpolations, replaceInterpolations } from '.';
 
 describe('ICU replacer', () => {
   it('should not error when no placeholders are present', () => {
@@ -37,5 +37,38 @@ describe('ICU replacer', () => {
       { from: '{test}', to: '<span translate="no">0</span>' },
       { from: '{placeholders}', to: '<span translate="no">1</span>' },
     ]);
+  });
+
+  it('should replace plural ICU syntax with placeholders', () => {
+    const { clean, replacements } = replaceInterpolations(
+      '{count} {count, plural, =1 {one person} =2 {two people} other {many people}}',
+      matchIcu,
+    );
+    expect(clean).toEqual(
+      '<span translate="no">0</span> <span translate="no">1</span>one person<span translate="no">2</span>two people<span translate="no">3</span>many people<span translate="no">4</span>',
+    );
+    expect(replacements).toEqual([
+      {
+        from: '{count} {count, plural, =1',
+        to: '<span translate="no">0</span>',
+      },
+      {
+        from: '{',
+        to: '<span translate="no">1</span>',
+      },
+      {
+        from: '} =2 {',
+        to: '<span translate="no">2</span>',
+      },
+      {
+        from: '} other {',
+        to: '<span translate="no">3</span>',
+      },
+      {
+        from: '}}',
+        to: '<span translate="no">4</span>',
+      },
+    ]);
+    expect(reInsertInterpolations(clean, replacements)).toEqual('{count} {count, plural, =1 {one person} =2 {two people} other {many people}}')
   });
 });

--- a/src/matchers/icu.ts
+++ b/src/matchers/icu.ts
@@ -1,21 +1,48 @@
 import { parse } from 'messageformat-parser';
 import { Matcher } from '.';
 
+type Plural = {
+  cases: [
+    {
+      tokens: string[];
+    },
+  ];
+};
+
+type ICUMatch = Plural | string;
+
 export const matchIcu: Matcher = (
   input: string,
   replacer: (i: number) => string,
 ) => {
+  const writeTokens = (part) => {
+    if (part?.cases?.length) {
+      return part.cases
+        .map((partCase) => {
+          return partCase.tokens.length
+            ? `(.*)${nestedIcuMatcher(partCase.tokens)}(.*)`
+            : '';
+        })
+        .join('');
+    } else {
+      return '(.*)';
+    }
+  };
+  const nestedIcuMatcher = (parts: ICUMatch[]): string => {
+    return (
+      parts
+        .map((part: ICUMatch) =>
+          typeof part === 'string'
+            ? part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            : writeTokens(part),
+        )
+        .join('')
+        // reduce replacement noise between replacements from nested tokens i.e. back to back (.*)(.*)
+        .replace(/(\(\.\*\)){2,}/g, '(.*)')
+    );
+  };
   const parts = parse(input);
-
-  const regex = new RegExp(
-    parts
-      .map((part: string) =>
-        typeof part === 'string'
-          ? part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-          : '(.*)',
-      )
-      .join(''),
-  );
+  const regex = new RegExp(nestedIcuMatcher(parts));
 
   const matches = input.match(regex);
 

--- a/src/matchers/icu.ts
+++ b/src/matchers/icu.ts
@@ -15,7 +15,7 @@ export const matchIcu: Matcher = (
   input: string,
   replacer: (i: number) => string,
 ) => {
-  const writeTokens = (part) => {
+  const writeTokens = (part: ICUMatch) => {
     if (part?.cases?.length) {
       return part.cases
         .map((partCase) => {
@@ -31,7 +31,7 @@ export const matchIcu: Matcher = (
   const nestedIcuMatcher = (parts: ICUMatch[]): string => {
     return (
       parts
-        .map((part: ICUMatch) =>
+        .map((part) =>
           typeof part === 'string'
             ? part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
             : writeTokens(part),


### PR DESCRIPTION
Adds support for ICU plural syntax. This pr ensures that these strings get placeholders added before sending to a translation service

```
{value, plural, =0 {No unread messages} one {{value} unread message} other {{value} unread messages} }
```

This change will mean that "No unread messages" "unread message" and "unread messages" would be sent to be translated instead of just all placeholders

Fixes: https://github.com/leolabs/json-autotranslate/issues/86