### PR TITLE
cache parameter: fix commander key name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -382,7 +382,7 @@ if (commander.listMatchers) {
 
 translate(
   commander.input,
-  commander.cacheDir,
+  commander.cache,
   commander.sourceLanguage,
   commander.deleteUnusedStrings,
   commander.type,


### PR DESCRIPTION
Hi!

It is just a fix for the commander's key name for the cache directory option.

This should fix the issue mentioned in https://github.com/leolabs/json-autotranslate/issues/88#issuecomment-1460738431