### PR TITLE
DeepL support context parameter, fix preserving newlines

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,10 @@ commander
     `specify the name of your app to distinguish DeepL glossaries (if sharing an API key between multiple projects)`,
     'json-autotranslate',
   )
+  .option(
+    '--context <context>',
+    `set the context that is used by DeepL for translations`,
+  )
   .option('--list-services', `outputs a list of available services`)
   .option(
     '-m, --matcher <matcher>',
@@ -107,6 +111,7 @@ const translate = async (
   config?: string,
   glossariesDir?: string,
   appName?: string,
+  context?: string,
 ) => {
   const workingDir = path.resolve(process.cwd(), inputDir);
   const resolvedCacheDir = path.resolve(process.cwd(), cacheDir);
@@ -172,6 +177,7 @@ const translate = async (
     decodeEscapes,
     glossariesDir,
     appName,
+    context,
   );
   console.log(chalk`└── {green.bold Done}`);
   console.log();
@@ -419,6 +425,7 @@ translate(
   commander.config,
   commander.glossaries,
   commander.appName,
+  commander.context,
 ).catch((e: Error) => {
   console.log();
   console.log(chalk.bgRed('An error has occurred:'));

--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -274,10 +274,12 @@ export class DeepL implements TranslationService {
       text: cleaned.map((c) => c.clean),
       source_lang: from.toUpperCase(),
       target_lang: to.toUpperCase(),
-      // see https://www.deepl.com/docs-api/html/disabling
+      // see https://developers.deepl.com/docs/xml-and-html-handling/html
       // set in order to indicate to DeepL that the interpolated strings that the matcher
       // replaced with `<span translate="no">${index}</span> should not be translated
       tag_handling: 'html',
+      // set to 1, because all newlines in the source text should be preserved
+      split_sentences: '1',
     };
 
     // Should a glossary be used?

--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -15,6 +15,7 @@ export class DeepL implements TranslationService {
   private apiEndpoint: string;
   private glossariesDir: string;
   private appName: string;
+  private context: string;
   private apiKey: string;
   /**
    * Number to tokens to translate at once
@@ -46,6 +47,7 @@ export class DeepL implements TranslationService {
     decodeEscapes?: boolean,
     glossariesDir?: string,
     appName?: string,
+    context?: string,
   ) {
     if (!config) {
       throw new Error(`Please provide an API key for ${this.name}.`);
@@ -62,6 +64,7 @@ export class DeepL implements TranslationService {
     this.decodeEscapes = decodeEscapes;
     this.glossariesDir = glossariesDir;
     this.appName = appName;
+    this.context = context;
   }
 
   async fetchLanguages() {
@@ -293,6 +296,11 @@ export class DeepL implements TranslationService {
     if (this.supportsFormality(to)) {
       // only append formality to avoid bad request error from deepl for languages with unsupported formality
       body['formality'] = this.formality;
+    }
+
+    if (this.context) {
+      // context is only added if it has been provided by as a command line argument
+      body['context'] = this.context;
     }
 
     // send request as a POST request, with all the tokens as separate texts in the body

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -24,6 +24,7 @@ export interface TranslationService {
     decodeEscapes?: boolean,
     glossariesDir?: string,
     appName?: string,
+    context?: string,
   ) => Promise<void>;
   supportsLanguage: (language: string) => boolean;
   translateStrings: (


### PR DESCRIPTION
- Support the alpha `context` parameter in DeepL translations: https://developers.deepl.com/docs/best-practices/working-with-context
- Fix an issue where the `\n` newlines were not preserved in translations using deepl