### PR TITLE
Check for existence of glossary file, not folder

### DIFF
--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -274,7 +274,8 @@ export class DeepL implements TranslationService {
     };
 
     // Should a glossary be used?
-    if (this.glossariesDir || this.automaticGlossary) {
+    const glossaryFilePath = path.join(this.glossariesDir, `${from}-${to}.json`);
+    if (fs.existsSync(glossaryFilePath) || this.automaticGlossary) {
       // Find the glossary that matches the source and target language:
       const glossary = await this.getGlossary(
         from,


### PR DESCRIPTION
This allows to have a glossary defined for some, but not all languages.