### PR TITLE
File not detected

### DIFF
--- a/src/util/file-system.ts
+++ b/src/util/file-system.ts
@@ -54,7 +54,7 @@ export const loadTranslations = (
       const type = fileType === 'auto' ? detectFileType(json) : fileType;
 
       return {
-        name: f,
+        name: path.basename(f),
         originalContent: json,
         type,
         content:


### PR DESCRIPTION
**Problem**

For some reason, the script wasn't caching all the existing files hence it was deleting those when I used the delete unused strings option. And also it was overwriting the translations to the source files.

**Solution**

The fileName in loadTranslations is the absolute path to the file. I just used the `path.basename()`.