### PR TITLE
Fix #142 Relative Path resolution in LoadTranslations

### DIFF
--- a/src/util/file-system.ts
+++ b/src/util/file-system.ts
@@ -48,7 +48,7 @@ export const loadTranslations = (
   fileType: FileType = 'auto',
   withArrays = false,
 ) =>
-  globSync(`${directory}/*.json`, { ignore: exclude }).map((f) => {
+  globSync(`${directory}/*.json`, { ignore: exclude, cwd: directory }).map((f) => {
     const json = require(path.resolve(directory, f));
     const type = fileType === 'auto' ? detectFileType(json) : fileType;
 


### PR DESCRIPTION
The cwd prop should set which directory the paths are relative to. I think this solves the issue in a more generic way than what we've been applying at work.

That said, I did this on lunch so I didn't have time to finish a working test.