### PR TITLE
DeepL: Send authKey in HTTP header when fetching languages

### DIFF
--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -76,10 +76,13 @@ export class DeepL implements TranslationService {
     }
 
     const url = new URL(`${this.apiEndpoint}/languages`);
-    url.searchParams.append('auth_key', this.apiKey);
     url.searchParams.append('type', 'target');
 
-    const response = await fetch(url.toString());
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: `DeepL-Auth-Key ${this.apiKey}`,
+      },
+    });
 
     if (!response.ok) {
       throw new Error('Could not fetch supported languages from DeepL');


### PR DESCRIPTION
- Send authKey in HTTP header when fetching languages
- https://developers.deepl.com/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods
- Was causing an error in our project Mustang: https://github.com/mustang-im/mustang/issues/1007